### PR TITLE
Support bounding set controll functions

### DIFF
--- a/mrblib/capability.rb
+++ b/mrblib/capability.rb
@@ -1,0 +1,5 @@
+class Capability
+  class << self
+    alias name2cap from_name
+  end
+end

--- a/src/mrb_capability.c
+++ b/src/mrb_capability.c
@@ -277,7 +277,14 @@ static mrb_value mrb_cap_drop_bound(mrb_state *mrb, mrb_value self)
 
 static mrb_value mrb_cap_is_supported(mrb_state *mrb, mrb_value self)
 {
-    return mrb_nil_value();
+    mrb_int cap;
+    mrb_get_args(mrb, "i", &cap);
+
+    if CAP_IS_SUPPORTED((cap_value_t)cap) {
+        return mrb_true_value();
+    } else {
+        return mrb_false_value();
+    }
 }
 
 void mrb_mruby_capability_gem_init(mrb_state *mrb)

--- a/src/mrb_capability.c
+++ b/src/mrb_capability.c
@@ -122,7 +122,7 @@ mrb_value mrb_cap_set(mrb_state *mrb, mrb_value self)
 
     return self;
 }
- 
+
 mrb_value mrb_cap_get(mrb_state *mrb, mrb_value self)
 {
     mrb_cap_context *cap_ctx = mrb_cap_get_context(mrb, self, "mrb_cap_context");
@@ -255,6 +255,21 @@ mrb_value mrb_cap_getgid(mrb_state *mrb, mrb_value self)
     return mrb_fixnum_value((mrb_int)getgid());
 }
 
+static mrb_value mrb_cap_get_bound(mrb_state *mrb, mrb_value self)
+{
+    return mrb_nil_value()
+}
+
+static mrb_value mrb_cap_drop_bound(mrb_state *mrb, mrb_value self)
+{
+    return mrb_nil_value()
+}
+
+static mrb_value mrb_cap_is_supported(mrb_state *mrb, mrb_value self)
+{
+    return mrb_nil_value()
+}
+
 void mrb_mruby_capability_gem_init(mrb_state *mrb)
 {
     struct RClass *capability;
@@ -270,6 +285,11 @@ void mrb_mruby_capability_gem_init(mrb_state *mrb)
     mrb_define_method(mrb, capability, "unset",         mrb_cap_clear,      MRB_ARGS_ANY());
     mrb_define_method(mrb, capability, "set_flag",      mrb_cap_set_flag,   MRB_ARGS_ANY());
     mrb_define_method(mrb, capability, "free",          mrb_cap_free,       MRB_ARGS_NONE());
+
+    // class methods
+    mrb_define_class_method(mrb, capability, "get_bound",  mrb_cap_get_bound,    MRB_ARGS_REQ(1));
+    mrb_define_class_method(mrb, capability, "drop_bound", mrb_cap_drop_bound,   MRB_ARGS_REQ(1));
+    mrb_define_class_method(mrb, capability, "supported?", mrb_cap_is_supported, MRB_ARGS_REQ(1));
 
     // test
     mrb_define_method(mrb, capability, "setuid",        mrb_cap_setuid,      MRB_ARGS_ANY());
@@ -329,4 +349,3 @@ void mrb_mruby_capability_gem_init(mrb_state *mrb)
 void mrb_mruby_capability_gem_final(mrb_state *mrb)
 {
 }
-

--- a/src/mrb_capability.c
+++ b/src/mrb_capability.c
@@ -296,6 +296,21 @@ static mrb_value mrb_cap_is_supported(mrb_state *mrb, mrb_value self)
     }
 }
 
+static mrb_value mrb_cap_from_name(mrb_state *mrb, mrb_value self)
+{
+    const char *cap_name;
+    cap_value_t cap;
+    int ret;
+    mrb_get_args(mrb, "z", &cap_name);
+
+    ret = cap_from_name(cap_name, &cap);
+    if(ret < 0){
+        mrb_sys_fail(mrb, "cap_from_name failed.");
+    }
+
+    return mrb_fixnum_value((mrb_int)cap);
+}
+
 void mrb_mruby_capability_gem_init(mrb_state *mrb)
 {
     struct RClass *capability;
@@ -316,6 +331,7 @@ void mrb_mruby_capability_gem_init(mrb_state *mrb)
     mrb_define_class_method(mrb, capability, "get_bound",  mrb_cap_get_bound,    MRB_ARGS_REQ(1));
     mrb_define_class_method(mrb, capability, "drop_bound", mrb_cap_drop_bound,   MRB_ARGS_REQ(1));
     mrb_define_class_method(mrb, capability, "supported?", mrb_cap_is_supported, MRB_ARGS_REQ(1));
+    mrb_define_class_method(mrb, capability, "from_name",  mrb_cap_from_name,    MRB_ARGS_REQ(1));
 
     // test
     mrb_define_method(mrb, capability, "setuid",        mrb_cap_setuid,      MRB_ARGS_ANY());

--- a/src/mrb_capability.c
+++ b/src/mrb_capability.c
@@ -36,6 +36,7 @@
 #include "mruby/data.h"
 #include "mruby/string.h"
 #include "mruby/array.h"
+#include "mruby/error.h"
 
 
 #define CAP_NUM 38
@@ -257,17 +258,26 @@ mrb_value mrb_cap_getgid(mrb_state *mrb, mrb_value self)
 
 static mrb_value mrb_cap_get_bound(mrb_state *mrb, mrb_value self)
 {
-    return mrb_nil_value()
+    mrb_int cap;
+    int ret;
+    mrb_get_args(mrb, "i", &cap);
+
+    ret = cap_get_bound((cap_value_t)cap);
+    if(ret < 0){
+        mrb_sys_fail(mrb, "cap_get_bound failed.");
+    }
+
+    return mrb_fixnum_value(ret);
 }
 
 static mrb_value mrb_cap_drop_bound(mrb_state *mrb, mrb_value self)
 {
-    return mrb_nil_value()
+    return mrb_nil_value();
 }
 
 static mrb_value mrb_cap_is_supported(mrb_state *mrb, mrb_value self)
 {
-    return mrb_nil_value()
+    return mrb_nil_value();
 }
 
 void mrb_mruby_capability_gem_init(mrb_state *mrb)

--- a/src/mrb_capability.c
+++ b/src/mrb_capability.c
@@ -272,7 +272,16 @@ static mrb_value mrb_cap_get_bound(mrb_state *mrb, mrb_value self)
 
 static mrb_value mrb_cap_drop_bound(mrb_state *mrb, mrb_value self)
 {
-    return mrb_nil_value();
+    mrb_int cap;
+    int ret;
+    mrb_get_args(mrb, "i", &cap);
+
+    ret = cap_drop_bound((cap_value_t)cap);
+    if(ret < 0){
+        mrb_sys_fail(mrb, "cap_drop_bound failed.");
+    }
+
+    return mrb_fixnum_value(ret);
 }
 
 static mrb_value mrb_cap_is_supported(mrb_state *mrb, mrb_value self)


### PR DESCRIPTION
Extra: added `cap_from_name` utility.

``` ruby
Capability.from_name "CAP_SYS_TIME"
# => 25

Capability.drop_bound Capability.name2cap("CAP_SYS_TIME")
# => 0
exec "/bin/bash" # with mruby-exec
```

``` console
[root@localhost vagrant]# LANG=C date -s 10:00
date: cannot set date: Operation not permitted
```
