### PR TITLE
Add inspect via `cap_to_text`

### DIFF
--- a/mrblib/capability.rb
+++ b/mrblib/capability.rb
@@ -8,4 +8,12 @@ class Capability
       return cap
     end
   end
+
+  def to_s
+    to_text
+  end
+
+  def inspect
+    "#<Capability #{to_s}>"
+  end
 end

--- a/mrblib/capability.rb
+++ b/mrblib/capability.rb
@@ -1,5 +1,11 @@
 class Capability
   class << self
     alias name2cap from_name
+
+    def get_proc
+      cap = new
+      cap.get_proc
+      return cap
+    end
   end
 end

--- a/src/mrb_capability.c
+++ b/src/mrb_capability.c
@@ -38,7 +38,6 @@
 #include "mruby/array.h"
 #include "mruby/error.h"
 
-
 #define CAP_NUM 38
 #define DONE    mrb_gc_arena_restore(mrb, 0);
 
@@ -219,6 +218,17 @@ mrb_value mrb_cap_free(mrb_state *mrb, mrb_value self)
     return self;
 }
 
+mrb_value mrb_cap_to_text(mrb_state *mrb, mrb_value self)
+{
+    mrb_cap_context *cap_ctx = mrb_cap_get_context(mrb, self, "mrb_cap_context");
+    char *to_s = cap_to_text(cap_ctx->cap, NULL);
+    if (to_s == NULL) {
+        mrb_sys_fail(mrb, "failed to get txt from cap");
+    }
+
+    return mrb_str_new_cstr(mrb, to_s);
+}
+
 // test
 mrb_value mrb_cap_setuid(mrb_state *mrb, mrb_value self)
 {
@@ -326,6 +336,7 @@ void mrb_mruby_capability_gem_init(mrb_state *mrb)
     mrb_define_method(mrb, capability, "unset",         mrb_cap_clear,      MRB_ARGS_ANY());
     mrb_define_method(mrb, capability, "set_flag",      mrb_cap_set_flag,   MRB_ARGS_ANY());
     mrb_define_method(mrb, capability, "free",          mrb_cap_free,       MRB_ARGS_NONE());
+    mrb_define_method(mrb, capability, "to_text",       mrb_cap_to_text,    MRB_ARGS_NONE());
 
     // class methods
     mrb_define_class_method(mrb, capability, "get_bound",  mrb_cap_get_bound,    MRB_ARGS_REQ(1));


### PR DESCRIPTION
This is useful for debug.

``` ruby
cap = Capability.get_proc
# => #<Capability = cap_chown,cap_dac_override,cap_dac_read_search,cap_fowner,cap_fsetid,cap_kill,cap_setgid,cap_setuid,cap_setpcap,cap_linux_immutable,cap_net_bind_serv
ice,cap_net_broadcast,cap_net_admin,cap_net_raw,cap_ipc_lock,cap_ipc_owner,cap_sys_module,cap_sys_rawio,cap_sys_chroot,cap_sys_ptrace,cap_sys_pacct,cap_sys_admin,cap_sys_bo
ot,cap_sys_nice,cap_sys_resource,cap_sys_time,cap_sys_tty_config,cap_mknod,cap_lease,cap_audit_write,cap_audit_control,cap_setfcap,cap_mac_override,cap_mac_admin,cap_syslog
,35,36+ep>
```
