### PR TITLE
Use new allocation api in `Capability.new`

### DIFF
--- a/src/mrb_capability.c
+++ b/src/mrb_capability.c
@@ -58,7 +58,8 @@ typedef struct {
 static void mrb_cap_context_free(mrb_state *mrb, void *p)
 {
     mrb_cap_context *ctx = (mrb_cap_context *)p;
-    //cap_free(ctx->cap);
+    cap_free(ctx->cap);
+    mrb_free(mrb, ctx);
 }
 
 static void mrb_file_cap_context_free(mrb_state *mrb, void *p)
@@ -78,7 +79,13 @@ static const struct mrb_data_type mrb_file_cap_context_type = {
 
 mrb_value mrb_cap_init(mrb_state *mrb, mrb_value self)
 {
-    mrb_cap_context *cap_ctx = (mrb_cap_context *)mrb_malloc(mrb, sizeof(mrb_cap_context));
+    mrb_cap_context *cap_ctx;
+
+    cap_ctx = (mrb_cap_context *)DATA_PTR(self);
+    if (cap_ctx) {
+        cap_free(cap_ctx->cap);
+    }
+    cap_ctx = (mrb_cap_context *)mrb_malloc(mrb, sizeof(mrb_cap_context));
 
     prctl(PR_SET_KEEPCAPS, 1);
     cap_ctx->cap = cap_init();
@@ -115,6 +122,9 @@ mrb_value mrb_cap_set(mrb_state *mrb, mrb_value self)
 mrb_value mrb_cap_get(mrb_state *mrb, mrb_value self)
 {
     mrb_cap_context *cap_ctx = (mrb_cap_context *)DATA_PTR(self);
+    if (cap_ctx && cap_ctx->cap) {
+        cap_free(cap_ctx->cap);
+    }
 
     cap_ctx->cap = cap_get_proc();
 

--- a/src/mrb_capability.c
+++ b/src/mrb_capability.c
@@ -388,6 +388,7 @@ void mrb_mruby_capability_gem_init(mrb_state *mrb)
     struct RClass *file;
 
     capability = mrb_define_class(mrb, "Capability", mrb->object_class);
+    MRB_SET_INSTANCE_TT(capability, MRB_TT_DATA);
 
     mrb_define_method(mrb, capability, "initialize",    mrb_cap_init,       MRB_ARGS_NONE());
     mrb_define_method(mrb, capability, "get",           mrb_cap_get,        MRB_ARGS_NONE());


### PR DESCRIPTION
Replaced (maybe) all of `mrb_iv_set` raw usage in the codes.

And I have fixed a potential memory leak.

``` bash
$ sudo ./mruby/bin/mruby -e 'loop {c = Capability.get_proc}'
# Raise no memory fattening
```
