### PR TITLE
Fix static build process, and add (experimental) CentOS 6 support

### DIFF
--- a/misc/fix-centos6-build.patch
+++ b/misc/fix-centos6-build.patch
@@ -1,0 +1,13 @@
+--- libcap/cap_file.c  2016-11-08 02:16:56.039007980 +0900
++++ libcap/cap_file.c.patched  2016-11-08 02:21:21.671008014 +0900
+@@ -10,6 +10,10 @@
+ #include <unistd.h>
+ #include <linux/xattr.h>
+ 
++#ifndef XATTR_NAME_CAPS
++#define XATTR_NAME_CAPS "security.capability"
++#endif
++
+ /*
+  * We hardcode the prototypes for the Linux system calls here since
+  * there are no libcap library APIs that expose the user to these

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -9,6 +9,8 @@ MRuby::Gem::Specification.new('mruby-capability') do |spec|
   unless defined?(LIBCAP_VERSION)
     LIBCAP_VERSION = "2.25"
     LIBCAP_TAG = "libcap-#{LIBCAP_VERSION}"
+    # tag libcap-2.25 is: https://kernel.googlesource.com/pub/scm/linux/kernel/git/morgan/libcap.git/+/libcap-2.25
+    LIBCAP_TARGET_COMMIT = "a0b240a1ead74be7851c98d58cc53c7c244ade58"
     LIBCAP_CHECKOUT_URL = "https://kernel.googlesource.com/pub/scm/linux/kernel/git/morgan/libcap.git"
   end
 
@@ -33,7 +35,7 @@ MRuby::Gem::Specification.new('mruby-capability') do |spec|
     FileUtils.mkdir_p File.dirname(libcap_dir(build))
     unless File.exist?(libcap_dir(build))
       run_command ENV, "git clone --depth=1 #{LIBCAP_CHECKOUT_URL} #{libcap_dir(build)}"
-      run_command ENV, "cd #{libcap_dir(build)} && git fetch origin -q && git checkout -q $(git rev-parse #{LIBCAP_TAG})"
+      run_command ENV, "cd #{libcap_dir(build)} && git fetch origin -q && git checkout -q #{LIBCAP_TARGET_COMMIT}"
 
       if `uname -r`.include? "2.6.32"
         # CentOS 6 patch

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -34,7 +34,7 @@ MRuby::Gem::Specification.new('mruby-capability') do |spec|
   file libcap_dir(build) do
     FileUtils.mkdir_p File.dirname(libcap_dir(build))
     unless File.exist?(libcap_dir(build))
-      run_command ENV, "git clone --depth=1 #{LIBCAP_CHECKOUT_URL} #{libcap_dir(build)}"
+      run_command ENV, "git clone #{LIBCAP_CHECKOUT_URL} #{libcap_dir(build)}"
       run_command ENV, "cd #{libcap_dir(build)} && git fetch origin -q && git checkout -q #{LIBCAP_TARGET_COMMIT}"
 
       if `uname -r`.include? "2.6.32"

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -34,6 +34,12 @@ MRuby::Gem::Specification.new('mruby-capability') do |spec|
     unless File.exist?(libcap_dir(build))
       run_command ENV, "git clone --depth=1 #{LIBCAP_CHECKOUT_URL} #{libcap_dir(build)}"
       run_command ENV, "cd #{libcap_dir(build)} && git fetch origin -q && git checkout -q $(git rev-parse #{LIBCAP_TAG})"
+
+      if `uname -r`.include? "2.6.32"
+        # CentOS 6 patch
+        patch_path = File.expand_path('../misc/fix-centos6-build.patch', __FILE__)
+        run_command ENV, "cd #{libcap_dir(build)} && patch -p0 < #{patch_path}"
+      end
     end
   end
 

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -33,7 +33,7 @@ MRuby::Gem::Specification.new('mruby-capability') do |spec|
     FileUtils.mkdir_p File.dirname(libcap_dir(build))
     unless File.exist?(libcap_dir(build))
       run_command ENV, "git clone --depth=1 #{LIBCAP_CHECKOUT_URL} #{libcap_dir(build)}"
-      run_command ENV, "cd #{libcap_dir(build)} && git fetch origin -q --tags #{LIBCAP_TAG} && git checkout -q $(git rev-parse #{LIBCAP_TAG})"
+      run_command ENV, "cd #{libcap_dir(build)} && git fetch origin -q && git checkout -q $(git rev-parse #{LIBCAP_TAG})"
     end
   end
 


### PR DESCRIPTION
* `git --tags` seems not to be supported by CentOS 6's git(and is unnecessary indeed), so removed
* `XATTR_NAME_CAPS` is not defined in 2.6.32 kernel, so added workaround patch

This allows us to build mruby-capability(and haconiwa) in CentOS 6 environment!