### PR TITLE
Check rpm -q kernel-headers result rather than uname

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -37,7 +37,7 @@ MRuby::Gem::Specification.new('mruby-capability') do |spec|
       run_command ENV, "git clone #{LIBCAP_CHECKOUT_URL} #{libcap_dir(build)}"
       run_command ENV, "cd #{libcap_dir(build)} && git fetch origin -q && git checkout -q #{LIBCAP_TARGET_COMMIT}"
 
-      if `uname -r`.include? "2.6.32"
+      if `rpm -q kernel-headers || true`.include? "2.6.32"
         # CentOS 6 patch
         patch_path = File.expand_path('../misc/fix-centos6-build.patch', __FILE__)
         run_command ENV, "cd #{libcap_dir(build)} && patch -p0 < #{patch_path}"


### PR DESCRIPTION
This is for builds inside docker, in which real kernel and package are unmatched

e.g. my centos6 image:

```
[root@cc28aaf68cc1 /]# uname -a
Linux cc28aaf68cc1 4.4.17-boot2docker #1 SMP Mon Aug 15 17:12:38 UTC 2016 x86_64 x86_64 x86_64 GNU/Linux
[root@cc28aaf68cc1 /]# yum info kernel-headers
Loaded plugins: fastestmirror, ovl
Loading mirror speeds from cached hostfile
 * base: www.ftp.ne.jp
 * epel: ftp.jaist.ac.jp
 * extras: www.ftp.ne.jp
 * updates: www.ftp.ne.jp
Installed Packages
Name        : kernel-headers
Arch        : x86_64
Version     : 2.6.32
Release     : 642.6.2.el6
Size        : 2.6 M
Repo        : installed
From repo   : updates
Summary     : Header files for the Linux kernel for use by glibc
URL         : http://www.kernel.org/
License     : GPLv2
Description : Kernel-headers includes the C header files that specify the interface
            : between the Linux kernel and userspace libraries and programs.  The
            : header files define structures and constants that are needed for
            : building most standard programs and are also needed for rebuilding the
            : glibc package.

```