### PR TITLE
[WIP]Support ambient capability API

### DIFF
--- a/.travis-build_config.rb
+++ b/.travis-build_config.rb
@@ -2,5 +2,8 @@ MRuby::Build.new do |conf|
   toolchain :gcc
   conf.gembox 'default'
   conf.gem File.expand_path(File.dirname(__FILE__))
+  if ENV['MRB_CAPABILITY_ENABLE_AMBIENT']
+    conf.cc.defines << 'MRB_CAPABILITY_ENABLE_AMBIENT'
+  end
   conf.enable_test
 end

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ compiler:
 env:
   - MRUBY_VERSION=1.2.0
   - MRUBY_VERSION=master
+  - MRUBY_VERSION=master MRB_CAPABILITY_ENABLE_AMBIENT=1
 script:
   - rake clean
   - rake test

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -17,6 +17,9 @@ MRuby::Gem::Specification.new('mruby-capability') do |spec|
   def libcap_dir(b); "#{b.build_dir}/libcap-#{LIBCAP_VERSION}"; end
   def libcap_libdir(b); "#{libcap_dir(b)}/libcap"; end
   def libcap_libfile(b); libfile("#{libcap_libdir(b)}/libcap"); end
+  def enable_ambient?(b)
+    b.cc.flags.flatten.include?('-DMRB_CAPABILITY_ENABLE_AMBIENT') || b.cc.defines.flatten.include?('MRB_CAPABILITY_ENABLE_AMBIENT')
+  end
 
   task :clean do
     FileUtils.rm_rf libcap_dir(build)
@@ -35,7 +38,9 @@ MRuby::Gem::Specification.new('mruby-capability') do |spec|
     FileUtils.mkdir_p File.dirname(libcap_dir(build))
     unless File.exist?(libcap_dir(build))
       run_command ENV, "git clone #{LIBCAP_CHECKOUT_URL} #{libcap_dir(build)}"
-      run_command ENV, "cd #{libcap_dir(build)} && git fetch origin -q && git checkout -q #{LIBCAP_TARGET_COMMIT}"
+      unless enable_ambient?(build)
+        run_command ENV, "cd #{libcap_dir(build)} && git fetch origin -q && git checkout -q #{LIBCAP_TARGET_COMMIT}"
+      end
 
       if `rpm -q kernel-headers || true`.include? "2.6.32"
         # CentOS 6 patch


### PR DESCRIPTION
In libcap head, these functions are implemented.

* `int cap_get_ambient(cap_value_t);`
* `int cap_set_ambient(cap_value_t, cap_flag_value_t);`
* `int cap_reset_ambient(void);`
* see: https://kernel.googlesource.com/pub/scm/linux/kernel/git/morgan/libcap/+/master/libcap/include/sys/capability.h#97

I want to provide the wrappers of these functions.