### PR TITLE
mruby 1.3.0、masterに対応

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ compiler:
   - clang
 env:
   - MRUBY_VERSION=1.2.0
+  - MRUBY_VERSION=1.3.0
   - MRUBY_VERSION=master
 script:
   - rake clean

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,5 @@
 MRUBY_CONFIG=File.expand_path(ENV["MRUBY_CONFIG"] || ".travis-build_config.rb")
-MRUBY_VERSION=ENV["MRUBY_VERSION"] || "1.2.0"
+MRUBY_VERSION=ENV["MRUBY_VERSION"] || "master"
 
 file :mruby do
   cmd =  "git clone --depth=1 git://github.com/mruby/mruby.git"

--- a/src/mrb_capability.c
+++ b/src/mrb_capability.c
@@ -105,7 +105,6 @@ mrb_value mrb_cap_set(mrb_state *mrb, mrb_value self)
   mrb_int identify;
 
   mrb_get_args(mrb, "iA", &identify, &ary);
-  struct RArray *a = mrb_ary_ptr(ary);
   int ncap = RARRAY_LEN(ary);
 
   for (i = 0; i < ncap; i++) {
@@ -140,7 +139,6 @@ mrb_value mrb_cap_clear(mrb_state *mrb, mrb_value self)
   mrb_int identify;
 
   mrb_get_args(mrb, "iA", &identify, &ary);
-  struct RArray *a = mrb_ary_ptr(ary);
   int ncap = RARRAY_LEN(ary);
 
   for (i = 0; i < ncap; i++) {
@@ -164,7 +162,6 @@ mrb_value mrb_cap_set_flag(mrb_state *mrb, mrb_value self)
   mrb_int state;
 
   mrb_get_args(mrb, "iAi", &identify, &ary, &state);
-  struct RArray *a = mrb_ary_ptr(ary);
   int ncap = RARRAY_LEN(ary);
 
   for (i = 0; i < ncap; i++) {
@@ -274,7 +271,6 @@ static mrb_value mrb_file_cap_set_file(mrb_state *mrb, mrb_value self)
   }
 
   mrb_get_args(mrb, "iA", &identify, &ary);
-  struct RArray *a = mrb_ary_ptr(ary);
   int ncap = RARRAY_LEN(ary);
 
   for (i = 0; i < ncap; i++) {
@@ -298,7 +294,6 @@ static mrb_value mrb_file_cap_clear(mrb_state *mrb, mrb_value self)
   mrb_int identify;
 
   mrb_get_args(mrb, "iA", &identify, &ary);
-  struct RArray *a = mrb_ary_ptr(ary);
   int ncap = RARRAY_LEN(ary);
 
   for (i = 0; i < ncap; i++) {

--- a/src/mrb_capability.c
+++ b/src/mrb_capability.c
@@ -106,10 +106,10 @@ mrb_value mrb_cap_set(mrb_state *mrb, mrb_value self)
 
   mrb_get_args(mrb, "iA", &identify, &ary);
   struct RArray *a = mrb_ary_ptr(ary);
-  int ncap = a->len;
+  int ncap = RARRAY_LEN(ary);
 
   for (i = 0; i < ncap; i++) {
-    cap_ctx->capval[i] = (cap_value_t)mrb_fixnum(a->ptr[i]);
+    cap_ctx->capval[i] = (cap_value_t)RARRAY_PTR(ary);
   }
 
   cap_set_flag(cap_ctx->cap, identify, ncap, cap_ctx->capval, CAP_SET);
@@ -141,10 +141,10 @@ mrb_value mrb_cap_clear(mrb_state *mrb, mrb_value self)
 
   mrb_get_args(mrb, "iA", &identify, &ary);
   struct RArray *a = mrb_ary_ptr(ary);
-  int ncap = a->len;
+  int ncap = RARRAY_LEN(ary);
 
   for (i = 0; i < ncap; i++) {
-    cap_ctx->capval[i] = (cap_value_t)mrb_fixnum(a->ptr[i]);
+    cap_ctx->capval[i] = (cap_value_t)RARRAY_PTR(ary);
   }
 
   cap_set_flag(cap_ctx->cap, identify, ncap, cap_ctx->capval, CAP_CLEAR);
@@ -165,10 +165,10 @@ mrb_value mrb_cap_set_flag(mrb_state *mrb, mrb_value self)
 
   mrb_get_args(mrb, "iAi", &identify, &ary, &state);
   struct RArray *a = mrb_ary_ptr(ary);
-  int ncap = a->len;
+  int ncap = RARRAY_LEN(ary);
 
   for (i = 0; i < ncap; i++) {
-    cap_ctx->capval[i] = (cap_value_t)mrb_fixnum(a->ptr[i]);
+    cap_ctx->capval[i] = (cap_value_t)RARRAY_PTR(ary);
   }
 
   cap_set_flag(cap_ctx->cap, identify, ncap, cap_ctx->capval, state);
@@ -275,10 +275,10 @@ static mrb_value mrb_file_cap_set_file(mrb_state *mrb, mrb_value self)
 
   mrb_get_args(mrb, "iA", &identify, &ary);
   struct RArray *a = mrb_ary_ptr(ary);
-  int ncap = a->len;
+  int ncap = RARRAY_LEN(ary);
 
   for (i = 0; i < ncap; i++) {
-    file_cap_ctx->capval[i] = (cap_value_t)mrb_fixnum(a->ptr[i]);
+    file_cap_ctx->capval[i] = (cap_value_t)RARRAY_PTR(ary);
   }
   cap_set_flag(file_cap_ctx->cap, identify, ncap, file_cap_ctx->capval, CAP_SET);
 
@@ -299,10 +299,10 @@ static mrb_value mrb_file_cap_clear(mrb_state *mrb, mrb_value self)
 
   mrb_get_args(mrb, "iA", &identify, &ary);
   struct RArray *a = mrb_ary_ptr(ary);
-  int ncap = a->len;
+  int ncap = RARRAY_LEN(ary);
 
   for (i = 0; i < ncap; i++) {
-    file_cap_ctx->capval[i] = (cap_value_t)mrb_fixnum(a->ptr[i]);
+    file_cap_ctx->capval[i] = (cap_value_t)RARRAY_PTR(ary);
   }
 
   cap_set_flag(file_cap_ctx->cap, identify, ncap, file_cap_ctx->capval, CAP_CLEAR);


### PR DESCRIPTION
- mruby1.3.0以上ではRArrayの構造体の中身が変更されているため、1.2.0でも互換性があるマクロを使用
`a->len`  -> `RARRAY_LEN(ary)`
`(cap_value_t)mrb_fixnum(a->ptr[i])`  -> `(cap_value_t)RARRAY_PTR(ary)`
- .travis.ymlに1.3.0の項目の追加
